### PR TITLE
add examples for: iam-identity-center module and s3-bucket-with-iam-role resources

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,14 @@
+# Local .terraform directories
+**/.terraform
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Ignore lockfiles in modules
+.terraform.lock.hcl
+
+# Crash log files
+crash.log
+
+**/.DS_Store

--- a/terraform/tf-tests/modules/iam-identity-center/data.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/data.tf
@@ -1,0 +1,119 @@
+# Fetch existing SSO Instance
+data "aws_ssoadmin_instances" "sso_instance" {}
+
+
+# The local variable 'users_and_their_groups' is a map of values for relevant user information.
+# It contians a list of all users with the name of their group_assignments appended to the end of the string.
+# This map is then fed into the 'identitystore_group' and 'identitystore_user' data sources with the 'for_each'
+# meta argument to fetch necessary information (group_id, user_id) for each user. These values are needed
+# to assign the sso users to groups.
+# Ex: nuzumaki_Admin = {
+# group_name = "Admin"
+# user_name = "nuzumaki"
+#     }
+#     nuzumaki_Dev = {
+# group_name = "Dev"
+# user_name = "nuzumaki"
+#     }
+#     suchihaQA = {
+# group_name = "QA"
+# user_name = "suchiha"
+#     }
+
+# - Fetch of SSO Groups to be used for group membership assignment -
+data "aws_identitystore_group" "existing_sso_groups" {
+  for_each          = local.users_and_their_groups
+  identity_store_id = local.sso_instance_id
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.value.group_name
+    }
+  }
+  // Prevents failure if data fetch is attempted before GROUPS are created
+  depends_on = [aws_identitystore_group.sso_groups]
+}
+
+
+# - Fetch of SSO Users to be used for group membership assignment -
+data "aws_identitystore_user" "existing_sso_users" {
+  for_each          = local.users_and_their_groups
+  identity_store_id = local.sso_instance_id
+
+  alternate_identifier {
+    # Filter users by user_name (nuzumaki, suchiha, dovis, etc.)
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = each.value.user_name
+    }
+  }
+  // Prevents failure if data fetch is attempted before USERS are created
+  depends_on = [aws_identitystore_user.sso_users]
+}
+
+
+# - Fetch of SSO Groups to be used for account assignments (for GROUPS) -
+data "aws_identitystore_group" "identity_store_group" {
+  for_each          = toset(local.account_assignments_for_groups)
+  identity_store_id = local.sso_instance_id
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.value
+    }
+  }
+  // Prevents failure if data fetch is attempted before GROUPS are created
+  depends_on = [aws_identitystore_group.sso_groups]
+}
+
+
+# - Fetch of SSO Groups to be used for account assignments (for USERS) -
+data "aws_identitystore_user" "identity_store_user" {
+  for_each          = toset(local.account_assignments_for_users)
+  identity_store_id = local.sso_instance_id
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = each.value
+    }
+  }
+  // Prevents failure if data fetch is attempted before USERS are created
+  depends_on = [aws_identitystore_user.sso_users]
+}
+
+
+# The local variable 'principals_and_their_permission_sets' is a map of values for relevant user information.
+# It contians a list of all users with the name of their group_assignments appended to the end of the string.
+# This map is then fed into the 'aws_ssoadmin_permission_set' data source with the 'for_each'meta argument to
+# fetch necessary information (principal_id , parget_id) for each principal (user/group). These values are needed
+# to assign permissions for users/groups to AWS accounts via account assignments.
+# Format is 'Type:<principal_type>__Principal:<principal_name>__Permission:<permission_set>__Account:<account_id>'
+
+# Ex: Type:GROUP__Principal:Admin__Permission:AdministratorAccess__Account:111111111111 = {
+# principal_name = "Admin"
+# principal_type = "GROUP"
+# permission_sets = "AdministratorAccess"
+# account_ids = "111111111111"
+#     }
+#     Type:GROUP__Principal:Admin__Permission:AdministratorAccess__Account:222222222222 = {
+#       # principal_name = "Admin"
+#       # principal_type = "GROUP"
+#       # permission_sets = "AdministratorAccess"
+#       # account_ids = "222222222222"
+#     }
+#     Type:GROUP__Principal:Admin__Permission:ViewOnlyAccess__Account:111111111111 = {
+# principal_name = "Admin"
+# principal_type = "GROUP"
+# permission_sets = "ViewOnlyAccess"
+# account_ids = "111111111111"
+#     }
+
+data "aws_ssoadmin_permission_set" "existing_permission_sets" {
+  for_each     = local.principals_and_their_account_assignments
+  instance_arn = local.ssoadmin_instance_arn
+  name         = each.value.permission_set
+  // Prevents failure if data fetch is attempted before Permission Sets are created
+  depends_on = [aws_ssoadmin_permission_set.pset]
+}

--- a/terraform/tf-tests/modules/iam-identity-center/examples/create-users-and-groups/locals.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/examples/create-users-and-groups/locals.tf
@@ -1,0 +1,14 @@
+# Fetch Account Id from SSM Parameter Store
+data "aws_ssm_parameter" "account1_account_id" {
+  name = "tf-aws-iam-idc-module-testing-account1-account-id" // replace with your SSM Parameter Key
+}
+
+locals {
+  # Account IDs
+  account1_account_id = nonsensitive(data.aws_ssm_parameter.account1_account_id.value)
+  # account1_account_id = "111111111111"
+  # account2_account_id = "222222222222"
+  # account3_account_id = "333333333333"
+  # account4_account_id = "444444444444"
+
+}

--- a/terraform/tf-tests/modules/iam-identity-center/examples/create-users-and-groups/main.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/examples/create-users-and-groups/main.tf
@@ -1,0 +1,85 @@
+module "aws-iam-identity-center" {
+  source = "../.." // local example
+  # source = "aws-ia/iam-identity-center/aws" // remote example
+
+  // Create desired GROUPS in IAM Identity Center
+  sso_groups = {
+    Admin : {
+      group_name        = "Admin"
+      group_description = "Admin IAM Identity Center Group"
+    },
+    Dev : {
+      group_name        = "Dev"
+      group_description = "Dev IAM Identity Center Group"
+    },
+    QA : {
+      group_name        = "QA"
+      group_description = "QA IAM Identity Center Group"
+    },
+    Audit : {
+      group_name        = "Audit"
+      group_description = "Audit IAM Identity Center Group"
+    },
+  }
+
+  // Create desired USERS in IAM Identity Center
+  sso_users = {
+    NarutoUzumaki : {
+      group_membership = ["Admin", "Dev", "QA", "Audit"]
+      user_name        = "nuzumaki"
+      given_name       = "Naruto"
+      family_name      = "Uzumaki"
+      email            = "nuzumaki@hiddenleaf.village"
+    },
+    SasukeUchiha : {
+      group_membership = ["QA", "Audit"]
+      user_name        = "suchiha"
+      given_name       = "Sasuke"
+      family_name      = "Uchiha"
+      email            = "suchiha@hiddenleaf.village"
+    },
+  }
+
+  // Create permissions sets backed by AWS managed policies
+  permission_sets = {
+    AdministratorAccess = {
+      description          = "Provides AWS full access permissions.",
+      session_duration     = "PT4H", // how long until session expires - this means 4 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+    ViewOnlyAccess = {
+      description          = "Provides AWS view only permissions.",
+      session_duration     = "PT3H", // how long until session expires - this means 3 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+  }
+
+  // Assign users/groups access to accounts with the specified permissions
+  account_assignments = {
+    Admin : {
+      principal_name  = "Admin"                                   // name of the user or group you wish to have access to the account(s)
+      principal_type  = "GROUP"                                   // entity type (user or group) you wish to have access to the account(s). Valid values are "USER" or "GROUP"
+      permission_sets = ["AdministratorAccess", "ViewOnlyAccess"] // permissions the user/group will have in the account(s)
+      account_ids = [                                             // account(s) the group will have access to. Permissions they will have in account are above line
+        local.account1_account_id,
+        # local.account2_account_id,
+        # local.account3_account_id, // these are defined in a locals.tf file, example is in this directory
+        # local.account4_account_id,
+      ]
+    },
+    Audit : {
+      principal_name  = "Audit"
+      principal_type  = "GROUP"
+      permission_sets = ["ViewOnlyAccess"]
+      account_ids = [
+        local.account1_account_id,
+        # local.account2_account_id,
+        # local.account3_account_id,
+        # local.account4_account_id,
+      ]
+    },
+  }
+
+}

--- a/terraform/tf-tests/modules/iam-identity-center/examples/existing-users-and-groups/locals.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/examples/existing-users-and-groups/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  # Account IDs
+  account1_account_id = "111111111111"
+  account2_account_id = "222222222222"
+  account3_account_id = "333333333333"
+  account4_account_id = "444444444444"
+
+}

--- a/terraform/tf-tests/modules/iam-identity-center/examples/existing-users-and-groups/main.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/examples/existing-users-and-groups/main.tf
@@ -1,0 +1,49 @@
+module "aws-iam-identity-center" {
+  source = "../.." // local example
+  # source = "aws-ia/iam-identity-center/aws" // remote example
+
+  // Create permissions sets backed by AWS managed policies
+  permission_sets = {
+    AdministratorAccess = {
+      description          = "Provides AWS full access permissions.",
+      session_duration     = "PT4H", // how long until session expires - this means 4 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+    ViewOnlyAccess = {
+      description          = "Provides AWS view only permissions.",
+      session_duration     = "PT3H", // how long until session expires - this means 3 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+  }
+
+  # Ensure these User/Groups already exist in your AWS account
+
+  // Assign users/groups access to accounts with the specified permissions
+  account_assignments = {
+    Admin : {
+      principal_name  = "Admin"                                   // name of the user or group you wish to have access to the account(s)
+      principal_type  = "GROUP"                                   // entity type (user or group) you wish to have access to the account(s). Valid values are "USER" or "GROUP"
+      permission_sets = ["AdministratorAccess", "ViewOnlyAccess"] // permissions the user/group will have in the account(s)
+      account_ids = [                                             // account(s) the group will have access to. Permissions they will have in account are above line
+        local.account1_account_id,                                // locals are used to allow for global changes to multiple account assignments
+        # local.account2_account_id, // if hard coding the account ids, you would need to change them in every place you want to change
+        # local.account3_account_id, // these are defined in a locals.tf file, example is in this directory
+        # local.account4_account_id,
+      ]
+    },
+    Audit : {
+      principal_name  = "Audit"
+      principal_type  = "GROUP"
+      permission_sets = ["ViewOnlyAccess"]
+      account_ids = [
+        local.account1_account_id,
+        local.account2_account_id,
+        local.account3_account_id,
+        local.account4_account_id,
+      ]
+    },
+  }
+
+}

--- a/terraform/tf-tests/modules/iam-identity-center/locals.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/locals.tf
@@ -1,0 +1,120 @@
+# - Users and Groups -
+locals {
+  # Create a new local variable by flattening the complex type given in the variable "sso_users"
+  flatten_user_data = flatten([
+    for this_user in keys(var.sso_users) : [
+      for group in var.sso_users[this_user].group_membership : {
+        user_name  = var.sso_users[this_user].user_name
+        group_name = group
+      }
+    ]
+  ])
+
+  users_and_their_groups = {
+    for s in local.flatten_user_data : format("%s_%s", s.user_name, s.group_name) => s
+  }
+
+}
+
+
+# - Permission Sets and Policies -
+locals {
+  # - Fetch SSO Instance ARN and SSO Instance ID -
+  ssoadmin_instance_arn = tolist(data.aws_ssoadmin_instances.sso_instance.arns)[0]
+  sso_instance_id       = tolist(data.aws_ssoadmin_instances.sso_instance.identity_store_ids)[0]
+
+  # Iterate over the objects in var.permission sets, then evaluate the expression's 'pset_name'
+  # and 'pset_index' with 'pset_name' and 'pset_index' only if the pset_index.managed_policies (AWS Managed Policy ARN)
+  # produces a result without an error (i.e. if the ARN is valid). If any of the ARNs for any of the objects
+  # in the map are invalid, the for loop will fail.
+
+  # pset_name is the attribute name for each permission set map/object
+  # pset_index is the corresponding index of the map of maps (which is the variable permission_sets)
+  aws_managed_permission_sets      = { for pset_name, pset_index in var.permission_sets : pset_name => pset_index if can(pset_index.aws_managed_policies) }
+  customer_managed_permission_sets = { for pset_name, pset_index in var.permission_sets : pset_name => pset_index if can(pset_index.customer_managed_policies) }
+
+  #  ! NOT CURRENTLY SUPPORTED !
+  # inline_policy_permission_sets = { for pset_name, pset_index in var.permission_sets : pset_name => pset_index if can(pset_index.inline_policy) }
+
+
+
+  # When using the 'for' expression in Terraform:
+  # [ and ] produces a tuple
+  # { and } produces an object, and you must provide two result expressions separated by the => symbol
+  # The 'flatten' function takes a list and replaces any elements that are lists with a flattened sequence of the list contents
+
+  # create pset_name and managed policy maps list. flatten is needed because the result is a list of maps.name
+  # This nested for loop will run only if each of the managed_policies are valid ARNs.
+
+  # - AWS Managed Policies -
+  pset_aws_managed_policy_maps = flatten([
+    for pset_name, pset_index in local.aws_managed_permission_sets : [
+      for policy in pset_index.aws_managed_policies : {
+        pset_name  = pset_name
+        policy_arn = policy
+      } if pset_index.aws_managed_policies != null && can(pset_index.aws_managed_policies)
+    ]
+  ])
+
+  # - Customer Managed Policies -
+  pset_customer_managed_policy_maps = flatten([
+    for pset_name, pset_index in local.customer_managed_permission_sets : [
+      for policy in pset_index.customer_managed_policies : {
+        pset_name   = pset_name
+        policy_name = policy
+        # path = path
+      } if pset_index.customer_managed_policies != null && can(pset_index.customer_managed_policies)
+    ]
+  ])
+
+  #  ! NOT CURRENTLY SUPPORTED !
+  # - Inline Policy -
+  #   pset_inline_policy_maps = flatten([
+  #     for pset_name, pset_index in local.inline_policy_permission_sets : [
+  #       for policy in pset_index.inline_policy : {
+  #         pset_name  = pset_name
+  #         inline_policy = policy
+  #         # path = path
+  #       } if pset_index.inline_policy != null && can(pset_index.inline_policy)
+  #     ]
+  #   ])
+
+}
+
+
+# - Account Assignments -
+locals {
+  # Create a new local variable by flattening the complex type given in the variable "account_assignments"
+  # This will be a 'tuple'
+  flatten_account_assignment_data = flatten([
+    for this_assignment in keys(var.account_assignments) : [
+      for account in var.account_assignments[this_assignment].account_ids : [
+        for pset in var.account_assignments[this_assignment].permission_sets : {
+          permission_set = pset
+          principal_name = var.account_assignments[this_assignment].principal_name
+          principal_type = var.account_assignments[this_assignment].principal_type
+          account_id     = account
+        }
+      ]
+    ]
+  ])
+
+
+  #  Convert the flatten_account_assignment_data tuple into a map.
+  # Since we will be using this local in a for_each, it must either be a map or a set of strings
+  principals_and_their_account_assignments = {
+    for s in local.flatten_account_assignment_data : format("Type:%s__Principal:%s__Permission:%s__Account:%s", s.principal_type, s.principal_name, s.permission_set, s.account_id) => s
+  }
+
+
+  # iterates over account_assignents, sets that to be assignment.principal_name ONLY if the assignment.principal_type
+  #is GROUP. Essentially stores all the possible 'assignments' (account assignments) that would be attached to a user group
+
+  # same thing, for sso_users but for USERs not GROUPs
+
+  # 'account_assignments_for_groups' is effectively a list of principal names where the account type is GROUP
+  account_assignments_for_groups = [for assignment in var.account_assignments : assignment.principal_name if assignment.principal_type == "GROUP"]
+
+  # 'account_assignments_for_users' is effectively a list of principal names where the account type is USER
+  account_assignments_for_users = [for assignment in var.account_assignments : assignment.principal_name if assignment.principal_type == "USER"]
+}

--- a/terraform/tf-tests/modules/iam-identity-center/main.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/main.tf
@@ -1,0 +1,210 @@
+# - IAM Identity Center Dynamic Group Creation -
+resource "aws_identitystore_group" "sso_groups" {
+  for_each          = var.sso_groups == null ? {} : var.sso_groups
+  identity_store_id = local.sso_instance_id
+  display_name      = each.value.group_name
+  description       = each.value.group_description
+}
+
+
+# - IAM Identity Center Dynamic User Creation -
+resource "aws_identitystore_user" "sso_users" {
+  for_each          = var.sso_users == null ? {} : var.sso_users
+  identity_store_id = local.sso_instance_id
+
+  # -- PROFILE DETAILS --
+  # - Primary Information -
+  // (Required) The name that is typically displayed when the user is referenced
+  // The default is the provided given name and family name.
+  # display_name = each.value.display_name
+  display_name = join(" ", [each.value.given_name, each.value.family_name])
+
+  //(Required, Forces new resource) A unique string used to identify the user. This value can consist of letters, accented characters, symbols, numbers, and punctuation. This value is specified at the time the user is created and stored as an attribute of the user object in the identity store. The limit is 128 characters
+  user_name = each.value.user_name
+
+  //(Required) Details about the user's full name. Detailed below
+  name {
+    // (Required) First name
+    given_name = each.value.given_name
+    // (Optional) Middle name
+    // Default value is null.
+    middle_name = lookup(each.value, "middle_name", null)
+    // (Required) Last name
+    family_name = each.value.family_name
+    // (Optional) The name that is typically displayed when the name is shown for display.
+    // Default value is the provided given name and family name.
+    formatted = lookup(each.value, "name_formatted", join(" ", [each.value.given_name, each.value.family_name]))
+    // (Optional) The honorific prefix of the user.
+    // Default value is null.
+    honorific_prefix = lookup(each.value, "honorific_prefix", null)
+    // (Optional) The honorific suffix of the user
+    // Default value is null.
+    honorific_suffix = lookup(each.value, "honorific_suffix", null)
+  }
+
+  // (Optional) Details about the user's email. At most 1 email is allowed. Detailed below.
+  // Required for this module to ensure users have an email on file for resetting password and receiving OTP.
+  emails {
+    // (Optional) The email address. This value must be unique across the identity store.
+    // Required for this module as explained above.
+    value = each.value.email
+    //(Optional) When true, this is the primary email associated with the user.
+    // Default value is true.
+    primary = lookup(each.value, "is_primary_email", true)
+    // (Optional) The type of email.
+    // Default value is null.
+    type = lookup(each.value, "email_type", null)
+  }
+
+  //(Optional) Details about the user's phone number. At most 1 phone number is allowed. Detailed below.
+  phone_numbers {
+    //(Optional) The user's phone number.
+    // Default value is null.
+    value = lookup(each.value, "phone_number", null)
+    // (Optional) When true, this is the primary phone number associated with the user.
+    // Default value is true.
+    primary = lookup(each.value, "is_primary_phone_number", true)
+    // (Optional) The type of phone number.
+    // // Default value is null.
+    type = lookup(each.value, "phone_number_type", null)
+  }
+
+  // (Optional) Details about the user's address. At most 1 address is allowed. Detailed below.
+  addresses {
+    // (Optional) The country that this address is in.
+    // Default value is null.
+    country = lookup(each.value, "country", null)
+    // (Optional) The address locality. You can use this for City/Town/Village
+    // Default value is null.
+    locality = lookup(each.value, "locality", null)
+    //(Optional) The name that is typically displayed when the address is shown for display.
+    // Default value is the provided street address, locality, region, postal code, and country.
+    formatted = lookup(each.value, "address_formatted", join(" ", [lookup(each.value, "street_address", ""), lookup(each.value, "locality", ""), lookup(each.value, "region", ""), lookup(each.value, "postal_code", ""), lookup(each.value, "country", "")]))
+    // (Optional) The postal code of the address.
+    // Default value is null.
+    postal_code = lookup(each.value, "postal_code", null)
+    // (Optional) When true, this is the primary address associated with the user.
+    // Default value is null.
+    primary = lookup(each.value, "is_primary_address", true)
+    // (Optional) The region of the address. You can use this for State/Parish/Province.
+    // Default value is true.
+    region = lookup(each.value, "region", null)
+    // (Optional) The street of the address.
+    // Default value is null.
+    street_address = lookup(each.value, "street_address", null)
+    // (Optional) The type of address.
+    // Default value is null.
+    type = lookup(each.value, "address_type", null)
+  }
+
+  # -- Additional information --
+  // (Optional) The user type.
+  // Default value is null.
+  user_type = lookup(each.value, "user_type", null)
+  // (Optional) The user's title. Ex. Developer, Principal Architect, Account Manager, etc.
+  // Default value is null.
+  title = lookup(each.value, "title", null)
+  // (Optional) The user's geographical region or location. Ex. US-East, EU-West, etc.
+  // Default value is null.
+  locale = lookup(each.value, "locale", null)
+  // (Optional) An alternate name for the user.
+  // Default value is null.
+  nickname = lookup(each.value, "nickname", null)
+  // (Optional) The preferred language of the user.
+  // Default value is null.
+  preferred_language = lookup(each.value, "preferred_language", null)
+  // (Optional) An URL that may be associated with the user.
+  // Default value is null.
+  profile_url = lookup(each.value, "profile_url", null)
+  // (Optional) The user's time zone.
+  // Default value is null.
+  # timezone = each.value.timezone
+  timezone = lookup(each.value, "timezone", null)
+
+  # ** IMPORTANT - NOT CURRENTLY SUPPORTED - Will add support when Terraform resource is updated. **
+  # employee_number = lookup(each.value, "employee_number", null)
+  # cost_center = lookup(each.value, "cost_center", null)
+  # organization = lookup(each.value, "organization", null)
+  # division = lookup(each.value, "division", null)
+  # department = lookup(each.value, "department", null)
+  # manager = lookup(each.value, "manager", null)
+
+}
+
+
+# - Identity Store Group Membership -
+resource "aws_identitystore_group_membership" "sso_group_membership" {
+  for_each          = local.users_and_their_groups
+  identity_store_id = local.sso_instance_id
+
+  group_id  = data.aws_identitystore_group.existing_sso_groups[each.key].group_id
+  member_id = data.aws_identitystore_user.existing_sso_users[each.key].user_id
+}
+
+
+# - SSO Permission Set -
+resource "aws_ssoadmin_permission_set" "pset" {
+  for_each = var.permission_sets
+  name     = each.key
+
+  # lookup function retrieves the value of a single element from a map, when provided it's key.
+  # if the given key does not exist, the default value (null) is returned instead
+
+  instance_arn     = local.ssoadmin_instance_arn
+  description      = lookup(each.value, "description", null)
+  relay_state      = lookup(each.value, "relay_state", null)      // (Optional) URL used to redirect users within the application during the federation authentication process
+  session_duration = lookup(each.value, "session_duration", null) // The length of time that the application user sessions are valid in the ISO-8601 standard
+  tags             = lookup(each.value, "tags", {})
+}
+
+
+# - AWS Managed Policy Attachment -
+resource "aws_ssoadmin_managed_policy_attachment" "pset_aws_managed_policy" {
+  # iterate over the permission_sets map of maps, and set the result to be pset_name and pset_index
+  # ONLY if the policy for each pset_index is valid.
+  for_each = { for pset in local.pset_aws_managed_policy_maps : "${pset.pset_name}.${pset.policy_arn}" => pset }
+
+  instance_arn       = local.ssoadmin_instance_arn
+  managed_policy_arn = each.value.policy_arn
+  permission_set_arn = aws_ssoadmin_permission_set.pset[each.value.pset_name].arn
+
+  depends_on = [aws_ssoadmin_account_assignment.account_assignment]
+}
+
+
+# - Customer Managed Policy Attachment -
+resource "aws_ssoadmin_customer_managed_policy_attachment" "pset_customer_managed_policy" {
+  for_each = { for pset in local.pset_customer_managed_policy_maps : "${pset.pset_name}.${pset.policy_name}" => pset }
+
+  instance_arn       = local.ssoadmin_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.pset[each.value.pset_name].arn
+  customer_managed_policy_reference {
+    name = each.value.policy_name
+    path = "/"
+  }
+
+}
+
+
+#  ! NOT CURRENTLY SUPPORTED !
+# - Inline Policy -
+# resource "aws_ssoadmin_permission_set_inline_policy" "pset_inline_policy" {
+#   for_each = { for pset_name, pset_index in var.permission_sets : pset_name => pset_index if can(pset_index.inline_policy) }
+
+#   inline_policy      = each.value.inline_policy[0]
+#   instance_arn       = local.ssoadmin_instance_arn
+#   permission_set_arn = aws_ssoadmin_permission_set.pset[each.key].arn
+# }
+
+resource "aws_ssoadmin_account_assignment" "account_assignment" {
+  for_each = local.principals_and_their_account_assignments // for_each arguement must be a map, or set of strings. Tuples won't work
+
+  instance_arn       = local.ssoadmin_instance_arn
+  permission_set_arn = data.aws_ssoadmin_permission_set.existing_permission_sets[each.key].arn
+
+  principal_id   = each.value.principal_type == "GROUP" ? data.aws_identitystore_group.identity_store_group[each.value.principal_name].id : data.aws_identitystore_user.identity_store_user[each.value.principal_name].id
+  principal_type = each.value.principal_type
+
+  target_id   = each.value.account_id
+  target_type = "AWS_ACCOUNT"
+}

--- a/terraform/tf-tests/modules/iam-identity-center/outputs.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/outputs.tf
@@ -1,0 +1,16 @@
+output "account_assignment_data" {
+  value       = local.flatten_account_assignment_data
+  description = "Tuple containing account assignment data"
+
+}
+
+output "principals_and_assignments" {
+  value       = local.principals_and_their_account_assignments
+  description = "Map containing account assignment data"
+
+}
+
+output "sso_groups_ids" {
+  value       = { for k, v in aws_identitystore_group.sso_groups : k => v.group_id }
+  description = "A map of SSO groups ids created by this module"
+}

--- a/terraform/tf-tests/modules/iam-identity-center/providers.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.14.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.35.0"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.55.0"
+    }
+  }
+}

--- a/terraform/tf-tests/modules/iam-identity-center/tests/create_users_and_groups_unit_and_e2e_tests_p1.tftest.hcl
+++ b/terraform/tf-tests/modules/iam-identity-center/tests/create_users_and_groups_unit_and_e2e_tests_p1.tftest.hcl
@@ -1,0 +1,109 @@
+# Create a unit and e2e test that creates the minimum required resources and validates that the names of the users and groups match the expected values
+
+# HINT: Make sure to run `terraform init` in this directory before running `terraform test`. Also, ensure you use constant values (e.g. string, number, bool, etc.) within your tests where at all possible or you may encounter errors.
+
+variables {
+  sso_groups = {
+    TestGroup1 : {
+      group_name        = "TestGroup1"
+      group_description = "TestGroup1 IAM Identity Center Group"
+    },
+    TestGroup2 : {
+      group_name        = "TestGroup2"
+      group_description = "Test IAM Identity Center Group"
+    },
+  }
+
+  // Create desired USERS in IAM Identity Center
+  sso_users = {
+    TestUser1 : {
+      group_membership = ["TestGroup1", "TestGroup2", ]
+      user_name        = "TestUser1"
+      given_name       = "Test"
+      family_name      = "User1"
+      email            = "testuser1@email.com"
+    },
+    TestUser2 : {
+      group_membership = ["TestGroup2", ]
+      user_name        = "TestUser2"
+      given_name       = "Test"
+      family_name      = "User2"
+      email            = "testuser2@email.com"
+    },
+  }
+
+  // Create permissions sets backed by AWS managed policies
+  permission_sets = {
+    AdministratorAccess = {
+      description          = "Provides AWS full access permissions.",
+      session_duration     = "PT4H", // how long until session expires - this means 4 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+    ViewOnlyAccess = {
+      description          = "Provides AWS view only permissions.",
+      session_duration     = "PT3H", // how long until session expires - this means 3 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+  }
+
+  // Assign users/groups access to accounts with the specified permissions
+  account_assignments = {
+    TestGroup1 : {
+      principal_name  = "TestGroup1"                              // name of the user or group you wish to have access to the account(s)
+      principal_type  = "GROUP"                                   // entity type (user or group) you wish to have access to the account(s). Valid values are "USER" or "GROUP"
+      permission_sets = ["AdministratorAccess", "ViewOnlyAccess"] // permissions the user/group will have in the account(s)
+      account_ids = [                                             // account(s) the group will have access to. Permissions they will have in account are above line
+        "286510435300",
+        # local.account2_account_id,
+        # local.account3_account_id, // these are defined in a locals.tf file, example is in this directory
+        # local.account4_account_id,
+      ]
+    },
+    TestGroup2 : {
+      principal_name  = "TestGroup2"
+      principal_type  = "GROUP"
+      permission_sets = ["ViewOnlyAccess"]
+      account_ids = [
+        "286510435300",
+        # local.account2_account_id,
+        # local.account3_account_id,
+        # local.account4_account_id,
+      ]
+    },
+  }
+}
+
+run "unit_tests" {
+  command = plan
+
+  # Check that the group_name for the "TestGroup1" group starts with "TestGroup1"
+  assert {
+    condition     = startswith(aws_identitystore_group.sso_groups["TestGroup1"].display_name, "TestGroup1")
+    error_message = "The Identity Store Group name (${aws_identitystore_group.sso_groups["TestGroup1"].display_name}  didn't match the expected value."
+  }
+
+  # Check that the user_name for the "TestUser1" user starts with "TestUser1"
+  assert {
+    condition     = startswith(aws_identitystore_user.sso_users["TestUser1"].user_name, "TestUser1")
+    error_message = "The Identity Store user name (${aws_identitystore_user.sso_users["TestUser1"].user_name}  didn't match the expected value."
+  }
+}
+
+run "e2e_tests" {
+  command = apply
+
+  # Check that the group_name for the "TestGroup1" group starts with "TestGroup1"
+  assert {
+    condition     = startswith(aws_identitystore_group.sso_groups["TestGroup1"].display_name, "TestGroup1")
+    error_message = "The Identity Store Group name (${aws_identitystore_group.sso_groups["TestGroup1"].display_name}  didn't match the expected value."
+  }
+
+  # Check that the user_name for the "TestUser1" user starts with "TestUser1"
+  assert {
+    condition     = startswith(aws_identitystore_user.sso_users["TestUser1"].user_name, "TestUser1")
+    error_message = "The Identity Store user name (${aws_identitystore_user.sso_users["TestUser1"].user_name}  didn't match the expected value."
+  }
+}
+

--- a/terraform/tf-tests/modules/iam-identity-center/tests/create_users_and_groups_unit_and_e2e_tests_p2.tftest.hcl
+++ b/terraform/tf-tests/modules/iam-identity-center/tests/create_users_and_groups_unit_and_e2e_tests_p2.tftest.hcl
@@ -1,0 +1,107 @@
+# Terraform code for a unit and e2e test that creates the minimum required resources and validates that the names of the users and groups match the expected values
+
+variables {
+  sso_groups = {
+    TestGroup1 : {
+      group_name        = "TestGroup1"
+      group_description = "TestGroup1 IAM Identity Center Group"
+    },
+    TestGroup2 : {
+      group_name        = "TestGroup2"
+      group_description = "Test IAM Identity Center Group"
+    },
+  }
+
+  // Create desired USERS in IAM Identity Center
+  sso_users = {
+    TestUser1 : {
+      group_membership = ["TestGroup1", "TestGroup2", ]
+      user_name        = "TestUser1"
+      given_name       = "Test"
+      family_name      = "User1"
+      email            = "testuser1@email.com"
+    },
+    TestUser2 : {
+      group_membership = ["TestGroup2", ]
+      user_name        = "TestUser2"
+      given_name       = "Test"
+      family_name      = "User2"
+      email            = "testuser2@email.com"
+    },
+  }
+
+  // Create permissions sets backed by AWS managed policies
+  permission_sets = {
+    AdministratorAccess = {
+      description          = "Provides AWS full access permissions.",
+      session_duration     = "PT4H", // how long until session expires - this means 4 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+    ViewOnlyAccess = {
+      description          = "Provides AWS view only permissions.",
+      session_duration     = "PT3H", // how long until session expires - this means 3 hours. max is 12 hours
+      aws_managed_policies = ["arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"]
+      tags                 = { ManagedBy = "Terraform" }
+    },
+  }
+
+  // Assign users/groups access to accounts with the specified permissions
+  account_assignments = {
+    TestGroup1 : {
+      principal_name  = "TestGroup1"                              // name of the user or group you wish to have access to the account(s)
+      principal_type  = "GROUP"                                   // entity type (user or group) you wish to have access to the account(s). Valid values are "USER" or "GROUP"
+      permission_sets = ["AdministratorAccess", "ViewOnlyAccess"] // permissions the user/group will have in the account(s)
+      account_ids = [                                             // account(s) the group will have access to. Permissions they will have in account are above line
+        "286510435300",
+        # local.account2_account_id,
+        # local.account3_account_id, // these are defined in a locals.tf file, example is in this directory
+        # local.account4_account_id,
+      ]
+    },
+    TestGroup2 : {
+      principal_name  = "TestGroup2"
+      principal_type  = "GROUP"
+      permission_sets = ["ViewOnlyAccess"]
+      account_ids = [
+        "286510435300",
+        # local.account2_account_id,
+        # local.account3_account_id,
+        # local.account4_account_id,
+      ]
+    },
+  }
+}
+
+run "unit_tests" {
+  command = plan
+
+  # Check that the group_name for the "TestGroup1" group starts with "TestGroup1"
+  assert {
+    condition     = startswith(aws_identitystore_group.sso_groups["TestGroup1"].display_name, "TestGroup1")
+    error_message = "The Identity Store Group name (${aws_identitystore_group.sso_groups["TestGroup1"].display_name}  didn't match the expected value."
+  }
+
+  # Check that the user_name for the "TestUser1" user starts with "TestUser1"
+  assert {
+    condition     = startswith(aws_identitystore_user.sso_users["TestUser1"].user_name, "TestUser1")
+    error_message = "The Identity Store user name (${aws_identitystore_user.sso_users["TestUser1"].user_name}  didn't match the expected value."
+  }
+}
+
+run "e2e_tests" {
+  command = apply
+
+  # Check that the group_name for the "TestGroup1" group starts with "TestGroup1"
+  assert {
+    condition     = startswith(aws_identitystore_group.sso_groups["TestGroup1"].display_name, "TestGroup1")
+    error_message = "The Identity Store Group name (${aws_identitystore_group.sso_groups["TestGroup1"].display_name}  didn't match the expected value."
+  }
+
+  # Check that the user_name for the "TestUser1" user starts with "TestUser1"
+  assert {
+    condition     = startswith(aws_identitystore_user.sso_users["TestUser1"].user_name, "TestUser1")
+    error_message = "The Identity Store user name (${aws_identitystore_user.sso_users["TestUser1"].user_name}  didn't match the expected value."
+  }
+}
+

--- a/terraform/tf-tests/modules/iam-identity-center/variables.tf
+++ b/terraform/tf-tests/modules/iam-identity-center/variables.tf
@@ -1,0 +1,46 @@
+# Groups
+variable "sso_groups" {
+  description = "Names of the groups you wish to create in IAM Identity Center"
+  type        = map(any)
+  default     = {}
+
+  # validation {
+  #   condition     = alltrue([for group in values(var.sso_groups) : length(group.group_name) >= 3 && length(group.group_name) <= 128])
+  #   error_message = "The name of one of the defined IAM Identity Center Groups is too long. Group names can be a maxmium of 128 characters, as the names are used by other resources throughout this module. This can cause deployment failures for AWS resources with smaller character limits for naming. Please ensure all group names are 128 characters or less, and try again."
+  # }
+}
+
+# Users
+variable "sso_users" {
+  description = "Names of the users you wish to create in IAM Identity Center"
+  type        = map(any)
+  default     = {}
+
+  validation {
+    condition     = alltrue([for user in values(var.sso_users) : length(user.user_name) >= 3 && length(user.user_name) <= 128])
+    error_message = "The name of one of the defined IAM Identity Center usernames is too long. Usernames can be a maxmium of 128 characters, as the names are used by other resources throughout this module. This can cause deployment failures for AWS resources with smaller character limits for naming. Please ensure all group names are 128 characters or less, and try again."
+  }
+}
+
+# Permission Sets
+variable "permission_sets" {
+  description = "Map of maps containing Permission Set names as keys. See permission_sets description in README for information about map values."
+  type        = any
+  default = {
+    # key
+    AdministratorAccess = {
+      # values
+      description      = "Provides full access to AWS services and resources.",
+      session_duration = "PT2H",
+      managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+    }
+  }
+}
+
+#  Account Assignments
+variable "account_assignments" {
+  description = "List of maps containing mapping between user/group, permission set and assigned accounts list. See account_assignments description in README for more information about map values."
+  type        = map(any)
+
+  default = {}
+}

--- a/terraform/tf-tests/resources/s3-bucket-with-iam-role/main.tf
+++ b/terraform/tf-tests/resources/s3-bucket-with-iam-role/main.tf
@@ -1,0 +1,32 @@
+# - Trust Relationships -
+data "aws_iam_policy_document" "ec2_trust_relationship" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "random_string" "example" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+# - IAM Role -
+resource "aws_iam_role" "example" {
+  name                = "example-prod-resource-${random_string.example.result}"
+  assume_role_policy  = data.aws_iam_policy_document.ec2_trust_relationship.json
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+
+  force_detach_policies = true
+}
+
+# - S3 Bucket -
+resource "aws_s3_bucket" "example" {
+  bucket_prefix = "example-prod-resource"
+  force_destroy = true
+}

--- a/terraform/tf-tests/resources/s3-bucket-with-iam-role/provider.tf
+++ b/terraform/tf-tests/resources/s3-bucket-with-iam-role/provider.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = var.aws_region
+
+
+  default_tags {
+    tags = {
+      Management = "Terraform"
+    }
+  }
+}

--- a/terraform/tf-tests/resources/s3-bucket-with-iam-role/tests/s3-bucket-with-iam-role_e2e-tests_p1.tftest.hcl
+++ b/terraform/tf-tests/resources/s3-bucket-with-iam-role/tests/s3-bucket-with-iam-role_e2e-tests_p1.tftest.hcl
@@ -1,0 +1,36 @@
+# Create an e2e test that creates the required resources and validates that the names of the iam role, iam policy, and s3 bucket starts with 'example-prod-resource'
+
+# HINT: Make sure to run `terraform init` in this directory before running `terraform test`. Also, ensure you use constant values (e.g. string, number, bool, etc.) within your tests where at all possible or you may encounter errors.
+
+# - End-to-end Tests -
+run "e2e_test" {
+  command = apply
+
+  # Using global variables defined above since additional variables block is not defined here
+  variables {
+    aws_region = "us-east-1"
+  }
+
+
+
+  # Assertions
+  # IAM Role - Ensure the role has the correct name, and trust policy after creation
+  assert {
+    condition     = startswith(aws_iam_role.example.id, "example-prod-resource")
+    error_message = "The IAM Role name (${aws_iam_role.example.name}) did not start with the expected value (example-prod-resource)."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role.example.assume_role_policy)["Statement"][0]["Principal"]["Service"] == "ec2.amazonaws.com"
+    error_message = "The IAM role trust policy (${aws_iam_role.example.assume_role_policy}) did not trust the expected service principal (ec2.amazonaws.com)"
+  }
+
+
+  # S3 - Ensure S3 Bucket have correct names after creation
+  assert {
+    condition     = startswith(aws_s3_bucket.example.id, "example-prod-resource")
+    error_message = "The S3 Remote State Bucket name (${aws_s3_bucket.example.id}) did not start with the expected value (example-prod-resource)."
+  }
+}
+
+

--- a/terraform/tf-tests/resources/s3-bucket-with-iam-role/tests/s3-bucket-with-iam-role_e2e_tests_p2.tftest.hcl
+++ b/terraform/tf-tests/resources/s3-bucket-with-iam-role/tests/s3-bucket-with-iam-role_e2e_tests_p2.tftest.hcl
@@ -1,0 +1,35 @@
+# Terraform code for e2e test that creates the required resources and validates that the names of the iam role, iam policy, and s3 bucket starts with 'example-prod-resource'
+
+# HINT: Make sure to run `terraform init` in this directory before running `terraform test`. Also, ensure you use constant values (e.g. string, number, bool, etc.) within your tests where at all possible or you may encounter errors.
+
+# - End-to-end Tests -
+run "e2e_test" {
+  command = apply
+
+  # Using global variables defined above since additional variables block is not defined here
+  variables {
+    aws_region = "us-east-1"
+  }
+
+
+  # Assertions
+  # IAM Role - Ensure the role has the correct name, and trust policy after creation
+  assert {
+    condition     = startswith(aws_iam_role.example.id, "example-prod-resource")
+    error_message = "The IAM Role name (${aws_iam_role.example.name}) did not start with the expected value (example-prod-resource)."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role.example.assume_role_policy)["Statement"][0]["Principal"]["Service"] == "ec2.amazonaws.com"
+    error_message = "The IAM role trust policy (${aws_iam_role.example.assume_role_policy}) did not trust the expected service principal (ec2.amazonaws.com)"
+  }
+
+
+  # S3 - Ensure S3 Bucket have correct names after creation
+  assert {
+    condition     = startswith(aws_s3_bucket.example.id, "example-prod-resource")
+    error_message = "The S3 Remote State Bucket name (${aws_s3_bucket.example.id}) did not start with the expected value (example-prod-resource)."
+  }
+}
+
+

--- a/terraform/tf-tests/resources/s3-bucket-with-iam-role/variables.tf
+++ b/terraform/tf-tests/resources/s3-bucket-with-iam-role/variables.tf
@@ -1,0 +1,6 @@
+variable "aws_region" {
+  type        = string
+  description = "The AWS region you wish to deploy your resources to."
+  default     = "us-east-1"
+
+}


### PR DESCRIPTION
This PR creates the project structure for the Terraform tests and includes the following tests.
- `create_users_and_groups_unit_and_e2e_tests_p1.tftest.hcl`
- `create_users_and_groups_unit_and_e2e_tests_p2.tftest.hcl`
- `s3-bucket-with-iam-role_e2e_tests_p1.tftest.hcl`
- `s3-bucket-with-iam-role_e2e_tests_p2.tftest.hcl`

Output of passing tests:
```hcl
❯ terraform test
tests/s3-bucket-with-iam-role_e2e-tests_p1.tftest.hcl... in progress
  run "e2e_test"... pass
tests/s3-bucket-with-iam-role_e2e-tests_p1.tftest.hcl... tearing down
tests/s3-bucket-with-iam-role_e2e-tests_p1.tftest.hcl... pass
tests/s3-bucket-with-iam-role_e2e_tests_p2.tftest.hcl... in progress
  run "e2e_test"... pass
tests/s3-bucket-with-iam-role_e2e_tests_p2.tftest.hcl... tearing down
tests/s3-bucket-with-iam-role_e2e_tests_p2.tftest.hcl... pass
```

```hcl
❯ terraform test
tests/create_users_and_groups_unit_and_e2e_tests_p1.tftest.hcl... in progress
  run "unit_tests"... pass
  run "e2e_tests"... pass
tests/create_users_and_groups_unit_and_e2e_tests_p1.tftest.hcl... tearing down
tests/create_users_and_groups_unit_and_e2e_tests_p1.tftest.hcl... pass
tests/create_users_and_groups_unit_and_e2e_tests_p2.tftest.hcl... in progress
  run "unit_tests"... pass
  run "e2e_tests"... pass
tests/create_users_and_groups_unit_and_e2e_tests_p2.tftest.hcl... tearing down
tests/create_users_and_groups_unit_and_e2e_tests_p2.tftest.hcl... pass
```